### PR TITLE
fix: use ascii underscore char in variable name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,9 @@ function create (_options?: Options): Middleware {
 
     if (shouldRedirect) {
       const _redirectHost = (options.redirectHost || req.headers.host || '').split(':')[0]
-      const ـredirectURL = 'https://' + _redirectHost + _port + url
-      res.writeHead(options.statusCode, { Location: ـredirectURL })
-      return res.end(ـredirectURL)
+      const _redirectURL = 'https://' + _redirectHost + _port + url
+      res.writeHead(options.statusCode, { Location: _redirectURL })
+      return res.end(_redirectURL)
     }
 
     return next && next()


### PR DESCRIPTION
The transpiled code shows that the `ـ` character used in the `ـredirectURL` variable name is not a regular underscore (ascii 137) but rather a 'ARABIC TATWEEL' (U+0640)


![Capture d’écran 2021-05-12 à 12 51 50](https://user-images.githubusercontent.com/813661/117963708-fffc9200-b320-11eb-8265-5aae60b0a0f6.png)
