### PR TITLE
Update ReadMe to add a note about using exclude for localhost or production.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ app.use(redirectSSL.create({
   enabled: process.env.NODE_ENV === 'production'
 }))
 ```
+Note that some browsers may cache the redirect response, which can cause the redirect to still occur even if you've disabled it. If you experience this issue, you can try using incognito mode in your browser or clearing your cache and cookies for localhost.
 
 ## Options
 


### PR DESCRIPTION
**Helpful note about excluding localhost & development:**
---
```
app.use(redirectSSL.create({
   exclude: ['localhost']
}))
```
"Note that some browsers may cache the redirect response, which can cause the redirect to still occur even if you've disabled it. If you experience this issue, you can try using incognito mode in your browser or clearing your cache and cookies for localhost."


---
**Reasoning behind this**
Many people in the issues, myself included ran into this problem. Easy solution is just a note about using incognito.

